### PR TITLE
Add support for .po headers

### DIFF
--- a/.clang-format
+++ b/.clang-format
@@ -1,0 +1,59 @@
+---
+Language:                               Cpp
+Standard:                               Cpp11
+IndentWidth:                            4 # I resent this isn't 2
+ContinuationIndentWidth:                4
+TabWidth:                               8
+UseTab:                                 Never
+ColumnLimit:                            80
+
+DerivePointerAlignment:                 false
+PointerAlignment:                       Left
+AlwaysBreakAfterDefinitionReturnType:   All
+AlwaysBreakTemplateDeclarations:        true
+
+BinPackParameters:                      false
+BinPackArguments:                       false
+ExperimentalAutoDetectBinPacking:       false
+
+AlignAfterOpenBracket:                  AlwaysBreak
+AlignEscapedNewlinesLeft:               false
+AllowShortFunctionsOnASingleLine:       Empty
+AllowShortIfStatementsOnASingleLine:    false
+AllowShortBlocksOnASingleLine:          false
+AllowShortLoopsOnASingleLine:           true # probably
+AllowShortCaseLabelsOnASingleLine:      false
+BreakBeforeBraces:                      Attach
+BreakBeforeBinaryOperators:             NonAssignment
+AlwaysBreakBeforeMultilineStrings:      true
+
+SpaceBeforeParens:                      ControlStatements
+SpaceAfterCStyleCast:                   false
+SpaceInEmptyParentheses:                false
+SpacesInParentheses:                    false
+SpacesInSquareBrackets:                 false
+SpacesInAngles:                         false
+SpacesInCStyleCastParentheses:          false
+SpacesInContainerLiterals:              true # ugh
+SpaceBeforeAssignmentOperators:         true
+
+IndentCaseLabels:                       false
+MaxEmptyLinesToKeep:                    1 # so generous. this should be 0
+Cpp11BracedListStyle:                   true
+NamespaceIndentation:                   Inner # maybe all? but only with 2 spaces
+
+SpacesBeforeTrailingComments:           1
+AlignTrailingComments:                  true
+CommentPragmas:                         '^TODO:' # maybe XXX as well?
+
+AccessModifierOffset:                   -2 # llvm style stuff that's probably right
+BreakBeforeBinaryOperators:             false
+BreakBeforeTernaryOperators:            true
+PenaltyBreakBeforeFirstCallParameter:   19
+PenaltyBreakComment:                    300
+PenaltyBreakString:                     1000
+PenaltyBreakFirstLessLess:              120
+PenaltyExcessCharacter:                 100000
+
+SortIncludes:                           false
+ReflowComments:                         false

--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,5 @@
 /*.json
 /a.out
 /po2json
+/core
+/obj

--- a/Makefile
+++ b/Makefile
@@ -1,8 +1,7 @@
-IDIR = ./include
 CXX = clang++
-CFLAGS = -I$(IDIR) \
-		 -I./third_party/CLI11/include \
-		 -I./third_party/rapidjson/include
+CFLAGS = -I./third_party/CLI11/include \
+		 -I./third_party/rapidjson/include \
+		 -g3
 
 ODIR = obj
 LDIR = ./lib
@@ -11,7 +10,7 @@ SDIR = ./src
 LIBS =
 
 _DEPS = po2json.hpp
-DEPS = $(patsubst %,$(IDIR)/%,$(_DEPS))
+DEPS = $(patsubst %,$(SDIR)/%,$(_DEPS))
 
 _OBJ = po2json.o
 OBJ = $(patsubst %,$(ODIR)/%,$(_OBJ))
@@ -36,6 +35,9 @@ pre-build:
 	else 														\
 		echo "INFO: No need to reinitialize git submodules"; 	\
 	fi
+	@if test ! -d $(ODIR) ; then \
+		mkdir $(ODIR);           \
+	fi
 
 clean:
-	rm -f $(ODIR)/*.o *~ core $(INCDIR)/*~
+	rm -rf $(ODIR) *~ core $(INCDIR)/*~

--- a/Makefile
+++ b/Makefile
@@ -1,7 +1,6 @@
 CXX = clang++
 CFLAGS = -I./third_party/CLI11/include \
-		 -I./third_party/rapidjson/include \
-		 -g3
+		 -I./third_party/rapidjson/include
 
 ODIR = obj
 LDIR = ./lib

--- a/Makefile
+++ b/Makefile
@@ -14,7 +14,9 @@ DEPS = $(patsubst %,$(SDIR)/%,$(_DEPS))
 _OBJ = po2json.o
 OBJ = $(patsubst %,$(ODIR)/%,$(_OBJ))
 
-.PHONY: all clean
+INSTALL_DIR = ~/.local/bin
+
+.PHONY: all clean install
 .SECONDARY: main-build
 
 all: pre-build main-build
@@ -40,3 +42,9 @@ pre-build:
 
 clean:
 	rm -rf $(ODIR) *~ core $(INCDIR)/*~
+
+install: all
+	@if test ! -d $(INSTALL_DIR) ; then \
+		mkdir -p $(INSTALL_DIR);        \
+	fi
+	cp po2json $(INSTALL_DIR);

--- a/obj/.gitignore
+++ b/obj/.gitignore
@@ -1,2 +1,0 @@
-*
-!.gitignore

--- a/src/po2json.hpp
+++ b/src/po2json.hpp
@@ -213,8 +213,7 @@ po2json(const std::string& file_contents, rapidjson::Document& po_json) {
 
         // If this is a msgid line, then:
         // 1) msgid must be a valid state.
-        // 2) We expect the next line to be either a string, msgstr, or
-        // msgid_plural.
+        // 2) We expect the next line to be either a string, msgstr, or msgid_plural.
         if (std::regex_match(line, submatch, msgid_regex)) {
             expect_state(State::msgid);
             current_state = State::msgid;
@@ -246,8 +245,7 @@ po2json(const std::string& file_contents, rapidjson::Document& po_json) {
 
         // If this is a msgstr_plural line, then:
         // 1) msgstr_plural must be a valid state.
-        // 2) We expect the next line to be either a string, msgstr_plural, or
-        // blank.
+        // 2) We expect the next line to be either a string, msgstr_plural, or blank.
         if (std::regex_match(line, submatch, msgstr_plural_regex)) {
             expect_state(State::msgstr_plural);
             current_state = State::msgstr_plural;

--- a/src/po2json.hpp
+++ b/src/po2json.hpp
@@ -84,7 +84,7 @@ po2json(const std::string& file_contents, rapidjson::Document& po_json) {
     const std::regex msgid_plural_regex(R"(msgid_plural\s+\"(.*)\")");
     const std::regex msgstr_plural_regex(R"(msgstr\[\d+\]\s+\"(.*)\")");
     const std::regex string_regex(R"(\"(.*)\")");
-    const std::regex header_key_value(R"(([a-zA-Z0-9-]+): (.*?)\\n)");
+    const std::regex header_key_value(R"(([a-zA-Z0-9-]+)\s*:\s*(.*?)\\n)");
 
     std::set<State> valid_next_states{State::msgctxt, State::msgid};
 


### PR DESCRIPTION
`.po` headers look something like this:

```po
msgid ""
msgstr ""
"Project-Id-Version: PACKAGE VERSION\n"
"Report-Msgid-Bugs-To: \n"
"POT-Creation-Date: 2020-10-23 12:00-0400\n"
"PO-Revision-Date: 2020-10-23 12:00-0400\n"
"Last-Translator: Automatically generated\n"
"Language-Team: none\n"
"Language: en\n"
"MIME-Version: 1.0\n"
"Content-Type: text/plain; charset=ASCII\n"
"Content-Transfer-Encoding: 8bit\n"
"Plural-Forms: nplurals=2; plural=(n != 1);\n"
```

po2json currently ignores any fields with an empty `msgid` which happens to correspond to the headers in the file.

This PR adds special handling for parsing out header values into JSON format. Here is an example of the output:

```json
{
    "": {
        "": {
            "Project-Id-Version": "PACKAGE VERSION",
            "Report-Msgid-Bugs-To": "",
            "POT-Creation-Date": "2020-10-23 12:00-0400",
            "PO-Revision-Date": "2020-10-23 12:00-0400",
            "Last-Translator": "Automatically generated",
            "Language-Team": "none",
            "Language": "en",
            "MIME-Version": "1.0",
            "Content-Type": "text/plain; charset=ASCII",
            "Content-Transfer-Encoding": "8bit",
            "Plural-Forms": "nplurals=2; plural=(n != 1);"
        },
        "About Me": {
            "translation": "About Me"
        },
        "Anime & Manga": {
            "translation": "Anime & Manga"
        }
    }
}
```

Indexing into an empty `msgctxt` and subsequently into an empty `msgid` will provide access to first-class JSON key-value pairs representing the header.

This is particularly useful because it exposes the critical `Plural-Forms` header which can be utilized to properly select plurals.

Note that `po2json` expects the headers to be delimited by `\n` and the key-value pairs should be delimited by `:`.